### PR TITLE
Patch 1 - Enclosing various powershell or other commands w/code apostrophe

### DIFF
--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex2_message_encryption.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex2_message_encryption.md
@@ -14,7 +14,7 @@ In this task, you will install the Exchange Online PowerShell module and verify 
 
 4. Enter the following cmdlet to install the latest Exchange Online PowerShell module version:
 
-    Install-Module ExchangeOnlineManagement
+    `Install-Module ExchangeOnlineManagement`
 
 5. Confirm the NuGet provider security dialog with **Y** for Yes and press **Enter**.
 
@@ -22,7 +22,7 @@ In this task, you will install the Exchange Online PowerShell module and verify 
 
 7. Enter the following cmdlet to change your execution policy and press **Enter**
 
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+    `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
 8. Confirm the Execution Policy Change with  **Y** for Yes and press **Enter**. 
 
@@ -32,17 +32,17 @@ In this task, you will install the Exchange Online PowerShell module and verify 
 
 11. Enter the following cmdlet to use the Exchange Online PowerShell module and connect to your tenant:
 
-    Connect-ExchangeOnline
+    `Connect-ExchangeOnline`
 
 12. When the **Sign in** window is displayed, sign in as sign in as JoniS@WWLxZZZZZZ.onmicrosoft.com (where ZZZZZZ is your unique tenant ID provided by your lab hosting provider).  Joni's password should be provided by your lab hosting provider.
 
 13. Verify Azure RMS and IRM is activated in your tenant by using the following cmdlet:
 
-    Get-IRMConfiguration | fl AzureRMSLicensingEnabled
+    `Get-IRMConfiguration | fl AzureRMSLicensingEnabled`
 
 14. Test the Azure RMS templates used for Office 365 Message Encryption against the other pilot user **Megan Bowen**:
 
-    Test-IRMConfiguration -Sender MeganB@contoso.com
+    `Test-IRMConfiguration -Sender MeganB@contoso.com`
 
 15. Verify all tests are in the status PASS and no errors are shown.
 
@@ -58,19 +58,19 @@ There is a requirement in your organization to restrict trust for foreign identi
 
 2. Run the following cmdlet to view the default OME configuration:
 
-    Get-OMEConfiguration -Identity "OME Configuration" |fl
+    `Get-OMEConfiguration -Identity "OME Configuration" |fl`
 
 3. Review the settings and confirm that the SocialIdSignIn parameter is set to True.
 
 4. Run the following cmdlet to restrict the use of social IDs for accessing messages from your tenant protected with OME:
 
-    Set-OMEConfiguration -Identity "OME Configuration" -SocialIdSignIn:$false
+    `Set-OMEConfiguration -Identity "OME Configuration" -SocialIdSignIn:$false`
 
 5. Confirm the warning message for customizing the default template with **"Y"** for Yes and press **Enter**.
 
 6. Check the default configuration again and validate, the SocialIdSignIn parameter is now set to False.
 
-    Get-OMEConfiguration -Identity "OME Configuration" |fl
+    `Get-OMEConfiguration -Identity "OME Configuration" |fl`
 
 7. Leave the PowerShell window and client open.
 
@@ -126,31 +126,31 @@ Protected messages sent by your organizations finance department require a speci
 
 2. Run the following cmdlet to create a new OME configuration:
 
-    New-OMEConfiguration -Identity "Finance Department" -ExternalMailExpiryInDays 7 
+    `New-OMEConfiguration -Identity "Finance Department" -ExternalMailExpiryInDays 7` 
 
 3. Confirm the warning message for customizing the template with **"Y"** for Yes and press **Enter**.
 
 4. Change the introduction text message with the following cmdlet:
 
-    Set-OMEConfiguration -Identity "Finance Department" -IntroductionText " from Contoso Ltd. finance department has sent you a secure message."
+    `Set-OMEConfiguration -Identity "Finance Department" -IntroductionText " from Contoso Ltd. finance department has sent you a secure message."`
 
 5. Confirm the warning message for customizing the template with **"Y"** for Yes and press **Enter**.
 
 6. Change the body email text of the message with the following cmdlet:
 
-    Set-OMEConfiguration -Identity "Finance Department" -EmailText "Encrypted message sent from Contoso Ltd. finance department. Handle the content responsibly."
+    `Set-OMEConfiguration -Identity "Finance Department" -EmailText "Encrypted message sent from Contoso Ltd. finance department. Handle the content responsibly."`
 
 7. Confirm the warning message for customizing the template with **"Y"** for Yes and press **Enter**.
 
 8. Change the disclaimer URL to point to Contoso's privacy statement site:
 
-    Set-OMEConfiguration -Identity "Finance Department" -PrivacyStatementURL "https://contoso.com/privacystatement.html"
+    `Set-OMEConfiguration -Identity "Finance Department" -PrivacyStatementURL "https://contoso.com/privacystatement.html"`
 
 9. Confirm the warning message for customizing the template with **"Y"** for Yes and press **Enter**..
 
 10. Use the following cmdlet to create a mail flow rule, which applies the custom OME template to all messages sent from the finance team.
 
-    New-TransportRule -Name "Encrypt all mails from Finance team" -FromScope InOrganization -FromMemberOf "Finance Team" -ApplyRightsProtectionCustomizationTemplate "Finance Department" -ApplyRightsProtectionTemplate Encrypt
+    `New-TransportRule -Name "Encrypt all mails from Finance team" -FromScope InOrganization -FromMemberOf "Finance Team" -ApplyRightsProtectionCustomizationTemplate "Finance Department" -ApplyRightsProtectionTemplate Encrypt`
 
 11. Leave the PowerShell open.
 

--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex3_Sensitive_Information_Types.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex3_Sensitive_Information_Types.md
@@ -194,15 +194,15 @@ To associate the EDM-based classification with a database containing sensitive d
 
 12. Enter the following text to the first line in the notepad window:
 
-    Name,Birthdate,StreetAddress,EmployeeID
+    `Name,Birthdate,StreetAddress,EmployeeID`
 
 13. Use enter and add the following text to the second line in the notepad window:
 
-    Joni Sherman,01.06.1980,1 Main Street,CSO123456
+    `Joni Sherman,01.06.1980,1 Main Street,CSO123456`
 
 14. Use enter and add the following text to the third line in the notepad window:
 
-    Lynne Robbins,31.01.1985,2 Secondary Street,CSO654321
+    `Lynne Robbins,31.01.1985,2 Secondary Street,CSO654321`
 
 15. Select **File** and **Save As** to save the file.
 
@@ -220,27 +220,27 @@ To associate the EDM-based classification with a database containing sensitive d
 
 22. Navigate to the EDM Upload Agent directory:
 
-    cd "C:\Program Files\Microsoft\EdmUploadAgent"
+    `cd "C:\Program Files\Microsoft\EdmUploadAgent"`
 
 23. Authorize with your Account to upload the database to your tenant by running the following:
 
-    .\EdmUploadAgent.exe /Authorize
+    `.\EdmUploadAgent.exe /Authorize`
 
 24. When the **Pick an account** window is displayed, sign in as JoniS@WWLxZZZZZZ.onmicrosoft.com (where ZZZZZZ is your unique tenant ID provided by your lab hosting provider).  Joni's password should be provided by your lab hosting provider.
 
 25. Download the database schema definition of the EDM-based classification sensitive information type by running the following script in PowerShell:
 
-    .\EdmUploadAgent.exe /SaveSchema /DataStoreName employeedb /OutputDir "C:\Users\Admin\Documents\"
+    `.\EdmUploadAgent.exe /SaveSchema /DataStoreName employeedb /OutputDir "C:\Users\Admin\Documents\"`
 
     Note: If the last command fails, it possibly takes more time until the **EDM_DataUploaders** group membership is applied. It can take up to one hour until it is possible to download the schema file.
 
 26. Hash the database file and upload it to the EDM-based classification sensitive information type by running the following script in PowerShell:
 
-    .\EdmUploadAgent.exe /UploadData /DataStoreName employeedb /DataFile "C:\Users\Admin\Documents\EmployeeData.csv" /HashLocation "C:\Users\Admin\Documents\" /Schema "C:\Users\Admin\Documents\employeedb.xml"
+    `.\EdmUploadAgent.exe /UploadData /DataStoreName employeedb /DataFile "C:\Users\Admin\Documents\EmployeeData.csv" /HashLocation "C:\Users\Admin\Documents\" /Schema "C:\Users\Admin\Documents\employeedb.xml"`
 
 27. Check the upload progress until the state changes to completed then run the following PowerShell command:
 
-    .\EdmUploadAgent.exe /GetSession /DataStoreName employeedb
+    `.\EdmUploadAgent.exe /GetSession /DataStoreName employeedb`
 
 28. Close the PowerShell window.
 
@@ -306,7 +306,7 @@ Custom Sensitive Information Types should always be tested before using them in 
 
 3. Enter the following text to the notepad window:
 
-    Employee Joni Sherman EMP123456 is on absence because of the flu/influenza.
+    `Employee Joni Sherman EMP123456 is on absence because of the flu/influenza.`
 
 4. Select **File** and **Save As**.
 

--- a/Instructions/Labs/LAB_AK_01_Lab1_Ex5_Sensitivity_Labels.md
+++ b/Instructions/Labs/LAB_AK_01_Lab1_Ex5_Sensitivity_Labels.md
@@ -15,19 +15,19 @@ In this task, you will install the MSOnline module and the SharePoint Online Pow
 
 4. Enter the following cmdlet to install the latest MS Online PowerShell module version:
 
-    Install-Module -Name MSOnline
+   `Install-Module -Name MSOnline`
 
 5. Confirm the Untrusted repository security dialog with **Y** for Yes and press Enter.
 
 6. Enter the following cmdlet to install the latest SharePoint Online PowerShell module version:
 
-    Install-Module -Name Microsoft.Online.SharePoint.PowerShell
+    `Install-Module -Name Microsoft.Online.SharePoint.PowerShell`
 
 7. Confirm the Untrusted repository security dialog with **Y** for Yes and press Enter.
 
 8. Enter the following cmdlet to connect to the MS Online service:
 
-    Connect-MsolService
+    `Connect-MsolService`
 
 9. In the **Sign in to your account** form, sign in as **Joni Sherman** JoniS@WWLxZZZZZZ.onmicrosoft.com (where ZZZZZZ is your unique tenant ID provided by your lab hosting provider).  Joni's password should be provided by your lab hosting provider.
 
@@ -35,15 +35,15 @@ In this task, you will install the MSOnline module and the SharePoint Online Pow
 
 11. Enter the following cmdlet to get the domain:
 
-    $domain = get-msoldomain
+    `$domain = get-msoldomain`
 
 12. Enter the following cmdlet to create the SharePoint admin url:
 
-    $adminurl = "https://" + $domain.Name.split('.')[0] + "-admin.sharepoint.com"
+    `$adminurl = "https://" + $domain.Name.split('.')[0] + "-admin.sharepoint.com"`
 
 13. Enter the following cmdlet to sign in to the SharePoint Online admin center:
 
-    Connect-SPOService -url $adminurl
+    `Connect-SPOService -url $adminurl`
 
 14. In the **Sign in to your account** form, sign in as **MOD Administrator**. admin@WWLxZZZZZZ.onmicrosoft.com (where ZZZZZZ is your unique tenant ID provided by your lab hosting provider).  Admin's password should be provided by your lab hosting provider.
 
@@ -51,7 +51,7 @@ In this task, you will install the MSOnline module and the SharePoint Online Pow
 
 16. Enter the following cmdlet to enable support for sensitivity labels:
 
-    Set-SPOTenant -EnableAIPIntegration $true
+    `Set-SPOTenant -EnableAIPIntegration $true`
 
 17. Confirm the changes with **Y** for Yes and press Enter. 
 
@@ -289,7 +289,7 @@ In this task, you will create a Sensitivity Label that will auto label documents
 
 14. In the **Search for sensitive info types** search panel, enter the following information: 
 
-    German
+    `German`
 
 15. Press the enter button, the results will display sensitivity info types related to Germany.
 

--- a/Instructions/Labs/LAB_AK_02_Lab1_Ex1_DLP_policies.md
+++ b/Instructions/Labs/LAB_AK_02_Lab1_Ex1_DLP_policies.md
@@ -90,15 +90,15 @@ In this task, you use PowerShell to create a DLP policy to protect driver's lice
 
 4. Enter the following command into PowerShell to create a DLP policy that scans all Exchange mailboxes:
 
-	New-DlpCompliancePolicy -Name "Driver's License DLP Policy" -Comment "This policy blocks sharing of Driver's License Numbers." -ExchangeLocation All
+	`New-DlpCompliancePolicy -Name "Driver's License DLP Policy" -Comment "This policy blocks sharing of Driver's License Numbers." -ExchangeLocation All`
 
 5. Enter the following command into PowerShell to add a DLP rule to the DLP policy you created in step 4:
 
-	New-DlpComplianceRule -Name "Driver's License Rule" -Policy "Driver's License DLP Policy" -BlockAccess $true -ContentContainsSensitiveInformation @{Name="U.S. Driver's License Number";minCount="1";minconfidence="75"}
+	`New-DlpComplianceRule -Name "Driver's License Rule" -Policy "Driver's License DLP Policy" -BlockAccess $true -ContentContainsSensitiveInformation @{Name="U.S. Driver's License Number";minCount="1";minconfidence="75"}`
 
 6. Use the following command to review the **Driver's License DLP Policy**:
 
-	Get-DLPComplianceRule -Identity "Driver's License Rule"
+	`Get-DLPComplianceRule -Identity "Driver's License Rule"`
 
 You have now created a DLP Policy that scans for Driver's license numbers in Exchange by using PowerShell.
 

--- a/Instructions/Labs/LAB_AK_03_Lab1_Ex1_retention_policies.md
+++ b/Instructions/Labs/LAB_AK_03_Lab1_Ex1_retention_policies.md
@@ -100,25 +100,25 @@ You will create the same retention policies with PowerShell
 
 3. Connect to the Security & Compliance Center in your tenant with the following cmdlet:
 
-    Connect-IPPSSession
+    `Connect-IPPSSession`
 
 4. If prompted with a sign in dialog box, sign in as **MOD Administrator** admin@WWLxZZZZZZ.onmicrosoft.com (where ZZZZZZ is your unique tenant ID provided by your lab hosting provider).  Admin's password should be provided by your lab hosting provider.
 
 5. Run the following cmdlet to create the first retention policy for all locations except teams:
 
-    New-RetentionCompliancePolicy -Name "Company Wide PS" -ExchangeLocation All -ModernGroupLocation All -PublicFolderLocation All -SharePointLocation All -OneDriveLocation All
+    `New-RetentionCompliancePolicy -Name "Company Wide PS" -ExchangeLocation All -ModernGroupLocation All -PublicFolderLocation All -SharePointLocation All -OneDriveLocation All`
 
 6. Run the following cmdlet to set the retention period, using days as units based the on the date modified:
 	
-    New-RetentionComplianceRule -Name "Company Wide PS Rule" -Policy "Company Wide PS" -RetentionDuration 1095 -ExpirationDateOption ModificationAgeInDays -RetentionComplianceAction Keep
+    `New-RetentionComplianceRule -Name "Company Wide PS Rule" -Policy "Company Wide PS" -RetentionDuration 1095 -ExpirationDateOption ModificationAgeInDays -RetentionComplianceAction Keep`
 
 7. Run the following cmdlet to create the second retention policy for Teams locations:
 
-    New-RetentionCompliancePolicy -Name "Teams Retention PS" -TeamsChannelLocation All -TeamsChatLocation "Adele Vance", "Pradeep Gupta"
+    `New-RetentionCompliancePolicy -Name "Teams Retention PS" -TeamsChannelLocation All -TeamsChatLocation "Adele Vance", "Pradeep Gupta"`
 
 8. Run the following cmdlet to set the retention period, using days as units:
 
-    New-RetentionComplianceRule -Name "Teams Retention PS Rule" -Policy "Teams Retention PS" -RetentionDuration 1095 -RetentionComplianceAction Keep
+    `New-RetentionComplianceRule -Name "Teams Retention PS Rule" -Policy "Teams Retention PS" -RetentionDuration 1095 -RetentionComplianceAction Keep`
 
 You have successfully created retention policies through PowerShell with a retention period of three years.
 

--- a/Instructions/Labs/LAB_AK_03_Lab1_Ex4_eDiscovery_recovery.md
+++ b/Instructions/Labs/LAB_AK_03_Lab1_Ex4_eDiscovery_recovery.md
@@ -108,11 +108,11 @@ An investigation showed that users received a few phishing mails and you are tas
 
 10. In the **PowerShell** window, use the following cmdlet and then sign in as **MOD Administrator**:
 
-	Connect-IPPSSession
+	`Connect-IPPSSession`
 
 11. In the **PowerShell** window, use the following command and confirm with **Y**:
 
-	New-ComplianceSearchAction -SearchName "Phishing mail removal" -Purge -PurgeType HardDelete
+	`New-ComplianceSearchAction -SearchName "Phishing mail removal" -Purge -PurgeType HardDelete`
 
 12. In PowerShell type **Y** for Yes to confirm the action.
 


### PR DESCRIPTION
# Module: various
## Lab/Demo: various

Fixes # .

Changes proposed in this pull request:

Through various instructions documents Powershell or other commands are only indented, but not enclosed in a markdown structure denoting them as 'code' or as 'code blocks'.  It is desirable for ALHs consuming these instructs to have these code formatting items present in order that items that will be input into the VMs can be automated properly.  This is what I have modified and proposed in this pull request.

Note that in this case I used the simpler form of: (single-apostrophe enclosing command)

    `example-powershell-command`

I used this in place of an actual code block (3-apostrophe enclosing commands(s)) since the vast majority of these commands were not multi-line.  If one has multi-line code blocks, one could also have chosen this as an equally valid way to fix for this issue:

    ```Powershell
    sample-ps-command-line1
    sample-ps-command-line2
    ```


